### PR TITLE
Add strand suffix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pandora2eager
 Title: Prepare an input TSV file for nf-core/eager with informations from Pandora
-Version: 0.5.0
+Version: 0.6.0
 Authors@R: 
     person("Thiseas Christos", "Lamnidis", email = "thiseas_christos_lamnidis@eva.mpg.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4485-8570"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: pandora2eager
-Title: Prepare an input TSV file for nf-core/eager with informations from Pandora
+Title: Prepare an input TSV file for nf-core/eager with information from Pandora
 Version: 0.6.0
 Authors@R: 
     person("Thiseas Christos", "Lamnidis", email = "thiseas_christos_lamnidis@eva.mpg.de", role = c("aut", "cre"),

--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ provided below:
 Usage: pandora2eager.sh [OPTIONS] /path/to/input_seq_IDs_file.txt
 
 Options:
-	-r/--rename	Changes all dots (.) in the Library_ID field of the output to underscores (_).
-			Some tools used in nf-core/eager will strip everything after the first dot (.)
-			from the name of the input file, which can cause naming conflicts in rare cases.
-	-h/--help	Usage information.
-	-v/--version	Version information.
-
+	-f/--file_type		Specify the file type of the input files. Accepted values are: 'bam', 'fastq_pathogens'.
+				Note: if this flag is not provided, raw fastq will be used to generate the table
+	-r/--rename		Changes all dots (.) in the Library_ID field of the output to underscores (_).
+				Some tools used in nf-core/eager will strip everything after the first dot (.)
+				from the name of the input file, which can cause naming conflicts in rare cases.
+	-d/--debug		Activate debug mode, it produces a file called: 'Debug_table.txt'.
+	-s/--add_ss_suffix		Adds the suffix '_ss' to the Sample_ID and Library_ID field of the output for single-stranded libraries.
+	-h/--help		Show usage information.
+	-v/--version		Show version information.
 
 ```
 
@@ -49,8 +52,7 @@ or Clemens Schmid to obtain them. You also have to be in the institute's subnet.
 You can get usage information and a descripition of optional arguments by running `pandora2eager.R`
 without specifying any arguments.
 ```
-
-Usage: pandora2eager.R [options] /path/to/input_seq_IDs_file.txt /path/to/pandora/.credentials
+Usage: ./exec/pandora2eager.R [options] /path/to/input_seq_IDs_file.txt /path/to/pandora/.credentials
 
 
 Options:
@@ -69,6 +71,9 @@ Options:
         -f FILE_TYPE, --file_type=FILE_TYPE
                 Specify the file type of the input files. Accepted values are: "bam", "fastq_pathogens". 
                         Note: if this flag is not provided, raw fastq will be used to generate the table
+
+        -s, --add_ss_suffix
+                Adds the suffix '_ss' to the Sample_ID and Library_ID field of the output for single-stranded libraries.
 
 ```
 

--- a/exec/pandora2eager.R
+++ b/exec/pandora2eager.R
@@ -144,11 +144,11 @@ parser <- add_option(parser, c("-f","--file_type"),
                         callback = validate_file_type,
                         default= NA,
                         dest = "file",
-                        help= 'Specify the file type of the input files. Accepted values are: \"bam\", \"fastq_pathogens\". \n\t\t\tNote: if this flag is not provided, raw fastq will be used to generate the table'),
+                        help= 'Specify the file type of the input files. Accepted values are: \"bam\", \"fastq_pathogens\". \n\t\t\tNote: if this flag is not provided, raw fastq will be used to generate the table')
 parser <- add_option(parser, c("-s","--add_ss_suffix"),
                         action = 'store_true',
                         dest = "ss_suffix",
-                        help = "Adds the suffix '_ss' to the Sample_ID and Library_ID field of the output for single-stranded libraries.",
+                        help = 'Adds the suffix \'_ss\' to the Sample_ID and Library_ID field of the output for single-stranded libraries.',
                         default = FALSE)
 
 argv <- parse_args(parser, positional_arguments = 2)

--- a/exec/pandora2eager.R
+++ b/exec/pandora2eager.R
@@ -162,7 +162,7 @@ results <- collect_and_format_info(query_list_seq, con, opts$file)
 DBI::dbDisconnect(con)
 
 ## Add suffixes if requested. This happens before debugging tables to reflect this behaviour in the debug table
-if ( opts$ss_suffix ) {
+if ( opts$ss_suffix == TRUE ) {
   results <- add_ss_suffix(results)
 }
 

--- a/exec/pandora2eager.R
+++ b/exec/pandora2eager.R
@@ -144,11 +144,11 @@ parser <- add_option(parser, c("-f","--file_type"),
                         callback = validate_file_type,
                         default= NA,
                         dest = "file",
-                        help= 'Specify the file type of the input files. Accepted values are: \"bam\", \"fastq_pathogens\". \n\t\t\tNote: if this flag is not provided, raw fastq will be used to generate the table')
+                        help= 'Specify the file type of the input files. Accepted values are: \"bam\", \"fastq_pathogens\". \n\t\t\tNote: if this flag is not provided, raw fastq will be used to generate the table'),
 parser <- add_option(parser, c("-s","--add_ss_suffix"),
                         action = 'store_true',
                         dest = "ss_suffix",
-                        help = 'Adds the suffix \'_ss\' to the Sample_ID and Library_ID field of the output for single-stranded libraries.',
+                        help = "Adds the suffix '_ss' to the Sample_ID and Library_ID field of the output for single-stranded libraries.",
                         default = FALSE)
 
 argv <- parse_args(parser, positional_arguments = 2)

--- a/exec/pandora2eager.R
+++ b/exec/pandora2eager.R
@@ -109,6 +109,23 @@ collect_and_format_info<- function(query_list_seq, con, file) {
   return(results_Final)
 }
 
+## Function to add a suffix to the Sample_ID and Library_ID field of the output for single-stranded libraries.
+add_ss_suffix <- function(results, suffix="_ss") {
+    x <- results %>%
+      mutate(
+        Sample_Name=case_when(
+          Strandedness == "single" ~ paste0(Sample_Name, suffix),
+          TRUE ~ Sample_Name
+        ),
+        Library_ID=case_when(
+          ## Insert the suffix after the first six characters (since Pandora individual IDs are always 6 characters long)
+          Strandedness == "single" ~ sub('^(.{6})(.*$)', paste0('\\1',suffix,'\\2'), Library_ID),
+          TRUE ~ Library_ID
+        )
+      )
+  return(x)
+}
+
 ## MAIN ##
 parser <- OptionParser(usage = "%prog [options] /path/to/input_seq_IDs_file.txt /path/to/pandora/.credentials")
 parser <- add_option(parser, c("-r","--rename"),
@@ -128,6 +145,11 @@ parser <- add_option(parser, c("-f","--file_type"),
                         default= NA,
                         dest = "file",
                         help= 'Specify the file type of the input files. Accepted values are: \"bam\", \"fastq_pathogens\". \n\t\t\tNote: if this flag is not provided, raw fastq will be used to generate the table')
+parser <- add_option(parser, c("-s","--add_ss_suffix"),
+                        action = 'store_true',
+                        dest = "ss_suffix",
+                        help = 'Adds the suffix \'_ss\' to the Sample_ID and Library_ID field of the output for single-stranded libraries.',
+                        default = FALSE)
 
 argv <- parse_args(parser, positional_arguments = 2)
 opts <- argv$options
@@ -136,6 +158,13 @@ query_list_seq <- read_tsv(argv$args[1], col_names = "Sequencing", col_types = '
 con <- get_pandora_connection(cred_file = argv$args[2])
 
 results <- collect_and_format_info(query_list_seq, con, opts$file)
+
+DBI::dbDisconnect(con)
+
+## Add suffixes if requested. This happens before debugging tables to reflect this behaviour in the debug table
+if ( opts$ss_suffix ) {
+  results <- add_ss_suffix(results)
+}
 
 if (opts$debug == TRUE) {
   write_tsv(results, "Debug_table.txt")

--- a/exec/pandora2eager.R
+++ b/exec/pandora2eager.R
@@ -148,7 +148,7 @@ parser <- add_option(parser, c("-f","--file_type"),
 parser <- add_option(parser, c("-s","--add_ss_suffix"),
                         action = 'store_true',
                         dest = "ss_suffix",
-                        help = 'Adds the suffix \'_ss\' to the Sample_ID and Library_ID field of the output for single-stranded libraries.',
+                        help = "Adds the suffix '_ss' to the Sample_ID and Library_ID field of the output for single-stranded libraries.",
                         default = FALSE)
 
 argv <- parse_args(parser, positional_arguments = 2)

--- a/helptext.sh
+++ b/helptext.sh
@@ -10,6 +10,7 @@ Options:
 			Some tools used in nf-core/eager will strip everything after the first dot (.)
 			from the name of the input file, which can cause naming conflicts in rare cases.
 	-d/--debug	Activate debug mode, it produces a file called: 'Debug_table.txt'.
+	-s/--add_ss_suffix	Adds the suffix '_ss' to the Sample_ID and Library_ID field of the output for single-stranded libraries.
 	-h/--help	Show usage information.
 	-v/--version	Show version information.
 

--- a/helptext.sh
+++ b/helptext.sh
@@ -4,14 +4,14 @@ echo "
 Usage: pandora2eager.sif /path/to/input_seq_IDs_file.txt [-r/--rename].
 
 Options:
-	-f/--file_type	Specify the file type of the input files. Accepted values are: 'bam', 'fastq_pathogens'.
-			Note: if this flag is not provided, raw fastq will be used to generate the table
-	-r/--rename	Changes all dots (.) in the Library_ID field of the output to underscores (_).
-			Some tools used in nf-core/eager will strip everything after the first dot (.)
-			from the name of the input file, which can cause naming conflicts in rare cases.
-	-d/--debug	Activate debug mode, it produces a file called: 'Debug_table.txt'.
+	-f/--file_type		Specify the file type of the input files. Accepted values are: 'bam', 'fastq_pathogens'.
+				Note: if this flag is not provided, raw fastq will be used to generate the table
+	-r/--rename		Changes all dots (.) in the Library_ID field of the output to underscores (_).
+				Some tools used in nf-core/eager will strip everything after the first dot (.)
+				from the name of the input file, which can cause naming conflicts in rare cases.
+	-d/--debug		Activate debug mode, it produces a file called: 'Debug_table.txt'.
 	-s/--add_ss_suffix	Adds the suffix '_ss' to the Sample_ID and Library_ID field of the output for single-stranded libraries.
-	-h/--help	Show usage information.
-	-v/--version	Show version information.
+	-h/--help		Show usage information.
+	-v/--version		Show version information.
 
 "

--- a/p2e_singularity.def
+++ b/p2e_singularity.def
@@ -28,4 +28,4 @@ From: rocker/tidyverse:4.1.1
 %labels
   Author  Thiseas C. Lamnidis
   GithubUrl https://github.com/sidora-tools/pandora2eager.git
-  Version 0.5.0
+  Version 0.6.0

--- a/pandora2eager.sh
+++ b/pandora2eager.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-VERSION="0.5.0"
-TEMP=`getopt -q -o hf:drv --long help,file_type:,rename,debug,version -n 'pandora2eager.sh' -- "$@"`
+VERSION="0.6.0"
+TEMP=`getopt -q -o hf:drvs --long help,file_type:,rename,debug,version,add_ss_suffix -n 'pandora2eager.sh' -- "$@"`
 eval set -- "$TEMP"
 
 image_path="/mnt/archgen/tools/pandora2eager/${VERSION}"
@@ -16,6 +16,7 @@ Options:
 			Some tools used in nf-core/eager will strip everything after the first dot (.)
 			from the name of the input file, which can cause naming conflicts in rare cases.
 	-d/--debug	Activate debug mode, it produces a file called: 'Debug_table.txt'.
+	-s/--add_ss_suffix	Adds the suffix '_ss' to the Sample_ID and Library_ID field of the output for single-stranded libraries.
 	-h/--help	Show usage information.
 	-v/--version	Show version information.
 
@@ -26,6 +27,7 @@ Options:
 rename=''
 file_type=''
 debug=''
+suffix=''
 
 while true ; do
   case "$1" in
@@ -39,6 +41,7 @@ while true ; do
     -v|--version) echo "Version: ${VERSION}"; exit 0;;
     -f|--file_type) file_type="-f $2"; shift 2;;
     -d|--debug) debug="-d"; shift 1;;
+    -s|--add_ss_suffix) suffix="-s"; shift 1;;
     *) echo -e "No Input file given.\n"; Helptext; exit 1;;
   esac
 done
@@ -48,4 +51,4 @@ input_path=$(dirname $(readlink -f ${fn1}))
 input_fn=$(basename ${fn1})
 mount_arg="${input_path}:/data"
 
-singularity run --bind ${mount_arg} ${image_path}/pandora2eager.sif /data/${input_fn} ${rename} ${file_type} ${debug}
+singularity run --bind ${mount_arg} ${image_path}/pandora2eager.sif /data/${input_fn} ${rename} ${suffix} ${file_type} ${debug}


### PR DESCRIPTION
Closes #11 
Adds an option (`-s`/`--add_ss_suffix`) to add the `_ss` suffix to all single-stranded Sample_IDs and Library_IDs.