### PR TITLE
correctly add ss_suffix to new longer pandora Site IDs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pandora2eager
 Title: Prepare an input TSV file for nf-core/eager with information from Pandora
-Version: 0.6.1
+Version: 0.6.2
 Authors@R: 
     person("Thiseas Christos", "Lamnidis", email = "thiseas_christos_lamnidis@eva.mpg.de", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4485-8570"))

--- a/exec/pandora2eager.R
+++ b/exec/pandora2eager.R
@@ -118,8 +118,8 @@ add_ss_suffix <- function(results, suffix="_ss") {
           TRUE ~ Sample_Name
         ),
         Library_ID=case_when(
-          ## Insert the suffix after the first six characters (since Pandora individual IDs are always 6 characters long)
-          Strandedness == "single" ~ sub('^(.{6})(.*$)', paste0('\\1',suffix,'\\2'), Library_ID),
+          ## Replace the first dot in the Library_ID with the suffix followed by a dot, to work with pandora Site IDs that are longer than 3 characters.
+          Strandedness == "single" ~ sub('\\.', paste0(suffix, '.'), Library_ID),
           TRUE ~ Library_ID
         )
       )

--- a/p2e_singularity.def
+++ b/p2e_singularity.def
@@ -28,4 +28,4 @@ From: rocker/tidyverse:4.1.1
 %labels
   Author  Thiseas C. Lamnidis
   GithubUrl https://github.com/sidora-tools/pandora2eager.git
-  Version 0.6.1
+  Version 0.6.2

--- a/pandora2eager.sh
+++ b/pandora2eager.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-VERSION="0.6.1"
+VERSION="0.6.2"
 TEMP=`getopt -q -o hf:drvs --long help,file_type:,rename,debug,version,add_ss_suffix -n 'pandora2eager.sh' -- "$@"`
 eval set -- "$TEMP"
 


### PR DESCRIPTION
This PR fixes the functionality of `--add_ss_suffix`, when working with new Pandora Site IDs that are longer than 3 characters.

Old behaviour: 
```
ABCD001.A0101.SG1.1 -> ABCD00_ss1.A0101.SG1.1
```

New behaviour:
```
ABCD001.A0101.SG1.1 -> ABCD001_ss.A0101.SG1.1
```